### PR TITLE
KAW-8140 Fix gap between text and stacked images

### DIFF
--- a/blocks/text-with-image/text-with-image.css
+++ b/blocks/text-with-image/text-with-image.css
@@ -241,6 +241,10 @@
   }
 
   /* stacked images variant */
+  .text-with-image.stacked-images .text-with-image-row {
+    gap: 104px;
+  }
+
   .text-with-image.stacked-images .column-with-images p:nth-child(2) img {
     width: 216px;
     right: 81px;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #KAW-8140

Test URLs:
- Before: https://redesign-develop--edge-delivery-bimota--netcentric.hlx.page/drafts/demo/2024-oct-3/text-with-image
- After: https://KAW-8140-fix-gap--edge-delivery-bimota--netcentric.hlx.page/drafts/demo/2024-oct-3/text-with-image
