### PR TITLE
KAW-8196 Fix text with image stacked overlapping next component

### DIFF
--- a/blocks/text-with-image/text-with-image.css
+++ b/blocks/text-with-image/text-with-image.css
@@ -17,6 +17,7 @@
   display: flex;
   flex-direction: column;
   gap: 48px;
+  overflow-x: clip;
 }
 
 .text-with-image .column-with-images {
@@ -72,6 +73,7 @@
   transform: translateY(
     calc(var(--text-image-2nd-image-height) - var(--text-image-distance))
   );
+  padding-bottom: calc(var(--text-image-2nd-image-height) - var(--text-image-distance));
   transition: transform var(--animation-time) linear;
 }
 
@@ -170,6 +172,7 @@
 
   .text-with-image.stacked-images .column-with-text {
     transform: unset;
+    padding: 0;
   }
 
   .text-with-image.stacked-images .column-with-images {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #kaw-8196

Test URLs:
- Before: https://redesign-develop--edge-delivery-bimota--netcentric.hlx.page/redesign/azienda
- After: https://kaw-8196--edge-delivery-bimota--netcentric.hlx.page/redesign/azienda